### PR TITLE
feat: do not transform already supported ES features

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function defaultHooks() {
 	addHook('.js');
 	addHook('.ts', {
 		transforms: ['imports', 'typescript'],
+		disableESTransforms: true,
 		// We ask Sucrase to preserve dynamic imports because we replace them
 		// ourselves.
 		preserveDynamicImport: true,


### PR DESCRIPTION
All those features are part of the ECMAScript spec, and supported natively on all non-EOL JS runtimes.