### PR TITLE
feat: add limited support for dynamic specifiers in dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ require('./myFile.ts'); // works
 - By default, we only support `.js` and `.ts` file extensions.
 - Windows would only support the `node -r @transloadit/ts-fly …` form, as the
   executable is a POSIX shell script.
+- Only literal specifiers which start with `./` and do not contain any `'` or
+  `"` char are fully supported. Support for dynamic imports with dynamic
+  specifiers is limited.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function addHook(extension, options) {
 	return pirates.addHook(
 		(code, filePath) => {
 			code = code.replace(
-				/\bimport(\(['"]\.[^'"]+\.ts['"]\))/g,
+				/\bimport(\(['"`]\.[^'"`]+\.ts[`'"]\))/g,
 				`Promise.resolve(require$1)`,
 			);
 			if (!options?.transforms) {

--- a/test/simple.test.mjs
+++ b/test/simple.test.mjs
@@ -24,10 +24,17 @@ await Promise.all([
 		}\n
     'use strict';
     console.log('this is not undefined', this !== undefined);
+	const dynamic = 'dynamic';
+	const dotDynamic = './dynamic';
     import './static-empty.ts';
     import('./dynamic.ts').then(module => console.log('dynamic', Object.keys(module)), console.error);
+    import(${'`'}./\${dynamic}.ts${'`'}).then(module => console.log('dynamic with var', Object.keys(module)), console.error);
     import('some-esm-package').then(module => console.log('some-esm-package', Object.keys(module)), console.error);
     import('some-cjs-package').then(module => console.log('some-cjs-package', Object.keys(module)), console.error);
+	// Only a subset of dynamic imports are supported, the following are not:
+    import(${'`'}./\${'dynamic'}.ts${'`'}).then(() => console.error('dynamic with literal', 'should have failed'), () => console.log('dynamic with literal', 'failed as expected'));
+    import(${'`'}\${dotDynamic}.ts${'`'}).then(() => console.error('dynamic with var 2', 'should have failed'), () => console.log('dynamic with var 2', 'failed as expected'));
+    import('./dyna' + 'mic.ts').then(() => console.error('dynamic with string concat', 'should have failed'), () => console.log('dynamic with string concat', 'failed as expected'));
     \n`,
 		'ascii',
 	),
@@ -83,6 +90,10 @@ try {
 	assert.strictEqual(stderr, '');
 	assert.match(stdout, /^this is not undefined true$/m);
 	assert.match(stdout, /^dynamic \[ 'default', 'a', 'b' \]$/m);
+	assert.match(stdout, /^dynamic with var \[ 'default', 'a', 'b' \]$/m);
+	assert.match(stdout, /^dynamic with literal failed as expected$/m);
+	assert.match(stdout, /^dynamic with var 2 failed as expected$/m);
+	assert.match(stdout, /^dynamic with string concat failed as expected$/m);
 	assert.match(stdout, /^some-esm-package \[ 'esm' \]$/m);
 	assert.match(stdout, /^some-cjs-package \[ 'cjs', 'default' \]$/m);
 	assert.deepStrictEqual(exitStatus, [0, null]);


### PR DESCRIPTION
Parsing ES with a regex is a dangerous idea, but as long as your not trying to do anything too "crazy", this PR should have you covered.