### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01
         id: release
         with:
           release-type: node


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/publish.yml`

Resolved refs:

- `google-github-actions/release-please-action@v3` -> `google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
